### PR TITLE
streamlit: add home page, navigation and create line encoding page

### DIFF
--- a/home.py
+++ b/home.py
@@ -1,0 +1,41 @@
+import streamlit as st
+
+
+
+st.set_page_config(
+    page_title = "Home",
+    page_icon = "🏠",
+)
+
+st.title("🌐 Data Communication Tools")
+
+st.markdown(
+    '''
+    Welcome to the Data Communication Tools, a comprehensive collection of powerful tools designed to simplify and enhance your data communication processes develoved by [Kantipur Engineering College Computer Club](https://github.com/computerclubkec). Whether you're working on source encoding, channel encoding, or line encoding, we've got you covered. Our curated set of utilities helps you encode, transmit, and decode data with reliability and efficiency.
+
+    Dive into the world of data communication and explore our range of tools, each crafted to meet the demands of modern technology. Join us in making data transmission seamless and robust. Contribute, innovate, and collaborate with our growing community!
+    '''
+)
+
+col1, col2, col3 = st.columns(3)
+
+with col1:
+    with st.container(border=True, height=
+                      250):
+        st.image("https://www.eeweb.com/wp-content/uploads/articles-quizzes-line-coding-1422602410.png")
+        if st.button("Line Encoding and Decoding"):
+            st.switch_page("pages/line.py")
+
+with col2:
+    with st.container(border=True, height=250):
+        st.image("https://media.geeksforgeeks.org/wp-content/uploads/20200122012046/edited2.png")
+        if st.button("Channel Encoding and Decoding"):
+            st.switch_page("pages/line.py")
+
+with col3:
+    with st.container(border=True, height=250):
+        st.image("https://media.springernature.com/lw685/springer-static/image/chp%3A10.1007%2F978-981-19-0920-7_3/MediaObjects/525386_1_En_3_Fig2_HTML.png")
+        st.write("\n")
+        st.write("\n")
+        if st.button("Source Encoding and Decoding"):
+            st.switch_page("pages/line.py")

--- a/pages/channel.py
+++ b/pages/channel.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.set_page_config(page_title="Channel Encoding and Decoding", page_icon="📡")

--- a/pages/line.py
+++ b/pages/line.py
@@ -1,0 +1,43 @@
+import streamlit as st
+from signals import Signals
+from line import bipolar_nrz, bipolar_rz, manchester, diff_manchester, polar_nrz, polar_rz, unipolar_nrz, unipolar_rz, nrz_invert, nrz_level
+
+st.set_page_config(page_title="Line Encoding and Decoding", page_icon="📈")
+
+signal_input = st.text_input("Enter Signal Bits", placeholder="Eg. 100101101") 
+option = st.selectbox("Select Line Encoding Method",
+                        ("---", "Bipolar NRZ", "Bipolar RZ", "Diff Manchester", "Manchester", "NRZ Invert", "NRZ Level", "Polar NRZ", "Polar RZ", "Unipolar NRZ", "Unipolar RZ"))
+
+enc_or_dec = st.selectbox("Encoding or Decoding the signal", ("Encoding", "Decoding"))
+
+
+if signal_input and option != "---" and enc_or_dec:
+    signal = Signals(signal_input)
+    
+    original_signal = signal.display(show=False)
+
+    line_functions = {
+        "Bipolar NRZ": bipolar_nrz,
+        "Bipolar RZ": bipolar_rz,
+        "Diff Manchester": diff_manchester,
+        "Manchester": manchester,
+        "NRZ Invert": nrz_invert,
+        "NRZ Level": nrz_level,
+        "Polar NRZ": polar_nrz,
+        "Polar RZ": polar_rz,
+        "Unipolar NRZ": unipolar_nrz,
+        "Unipolar RZ": unipolar_rz 
+    } 
+    
+    sel_method = line_functions[option]
+
+
+    METHOD_SUFFIX = "_encode" if enc_or_dec == "Encoding" else "_decode"
+    method_name = option.lower().replace(" ","_") + METHOD_SUFFIX
+    method_to_call = getattr(sel_method, method_name)
+    method_to_call(signal)
+
+    if sel_method and enc_or_dec:
+        st.pyplot(original_signal)
+        st.pyplot(signal.display(show=False))
+

--- a/pages/source.py
+++ b/pages/source.py
@@ -1,0 +1,3 @@
+import streamlit as st
+
+st.set_page_config(page_title="Source Encoding and Decoding", page_icon="🌲")

--- a/signals.py
+++ b/signals.py
@@ -91,17 +91,19 @@ class Signals:
         self.name = "Original Signal"
         self.signal = self.intial_bits
 
-    def display(self) -> None:
+    def display(self, show=True) -> plt.figure:
         """
         Display a plot of the binary signal with timestamps and labels.
 
         Returns:
-            None
+           matplotlib figure 
         """
-        plt.figure()
+        fig = plt.figure()
         plt.plot(self.bits_duration, self.signal)
         plt.grid(True)
         plt.xticks(range(0, len(self.bits) + 1))
         plt.yticks([-1, 0, 1])
         plt.title(f"{self.name} for: {self.intial_bits}")
-        plt.show()
+        if show:
+            plt.show()
+        return fig


### PR DESCRIPTION
This PR will:
- add the home page and navigation to line encoding, source encoding and channel encoding.
- modify the display method of signal class; a boolean to decide either to return the figure drawn for streamlit or just display locally